### PR TITLE
Feat: Add centralized configurations TRA-148

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
 # Database
-DB_URL= jdbc:postgresql://host_name:5432/db_name # hostname-> localhost
+DB_URL= <url>
 DB_USERNAME= <user-name>
 DB_PASSWORD= <user-password>
+
+# Config Server
+CONFIG_SERVER_URL= <url>
+DB_HOSTNAME= <name>
+
+# Eureka Server
+SPRING_EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=<url>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,28 +2,8 @@ spring:
   application:
     name: assessment-service
 
-  datasource:
-    url: ${DB_URL}
-    driver-class-name: org.postgresql.Driver
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
-        format_sql: true
-
-  sql:
-    init:
-      mode: always
-
-logging:
-  level:
-    org.hibernate.sql: DEBUG
-    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-server:
-  port: 9000
+  config:
+    import: 'configserver:'
+  cloud:
+    config:
+      uri: ${SPRING_CLOUD_CONFIG_URI}


### PR DESCRIPTION
## 🔗 Jira Issue

Closes [TRA-148](https://amali-tech.atlassian.net/jira/software/projects/TRA/boards/1721?selectedIssue=TRA-148)

## 📄 Description

This PR integrates centralized configuration support into the `assessment-service` as part of our microservices architecture.

### Key Updates:
- Externalized configuration by creating a new `assessment-service.yml` file in the centralized configuration repository.
- Removed local configuration values from `application.yml` to prevent conflicts or overwrites.
- Updated `.env.example` to reflect required environment variables for consistency with the actual `.env` file 
- Added `spring-cloud-starter-config` dependency in `pom.xml` to enable integration with Spring Cloud Config Server.

These changes align the `assessment-service` with the architecture standards for centralized configuration management.

## 🧪 How to Test

1. Start the Spring Cloud Config Server and ensure it has access to the updated centralized config repository.
2. Run the `assessment-service`.
3. Verify that the service loads its configuration from the central config server.
4. Ensure no errors or conflicts arise from missing or conflicting `application.yml` entries.

## ✅ Checklist

- [x] Jira ticket linked in title or description
- [x] Follows branch naming convention: `feat/add-centralized-configurations-TRA-148`
- [x] Follows commit naming convention: `feat: Add centralized configurations`
- [x] Code tested 
- [x] Documentation updated (`.env.example`)
- [x] No sensitive data or secrets committed

## 📝 Additional Notes

- All changes are backward-compatible with the centralized config setup.
- This is a foundational change to support future environment-specific configuration management.
