### PR TITLE
Feat/Create Assessment Service TRA-31

### DIFF
--- a/src/main/java/com/talentradar/assessment_service/config/SecurityConfig.java
+++ b/src/main/java/com/talentradar/assessment_service/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.talentradar.assessment_service.config;
+
+import com.talentradar.assessment_service.filter.UserContextFilter;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final UserContextFilter userContextFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/actuator/health"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setContentType("application/json");
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.getWriter().write("{\"error\":\"Unauthorized\",\"message\":\"JWT token is missing or invalid\"}");
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.setContentType("application/json");
+                            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                            response.getWriter().write("{\"error\":\"Forbidden\",\"message\":\"You don't have permission to access this resource\"}");
+                        })
+                )
+                .addFilterBefore(userContextFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/talentradar/assessment_service/controller/AssessmentController.java
+++ b/src/main/java/com/talentradar/assessment_service/controller/AssessmentController.java
@@ -1,0 +1,50 @@
+package com.talentradar.assessment_service.controller;
+
+import com.talentradar.assessment_service.dto.assessment.request.AssessmentRequestDTO;
+import com.talentradar.assessment_service.dto.assessment.response.AssessmentResponseDTO;
+import com.talentradar.assessment_service.dto.api.ApiResponse;
+import com.talentradar.assessment_service.dto.assessment.response.PaginatedResponseDTO;
+import com.talentradar.assessment_service.service.AssessmentService;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/assessments")
+@RequiredArgsConstructor
+public class AssessmentController {
+
+    private final AssessmentService assessmentService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('DEVELOPER')")
+    public ResponseEntity<ApiResponse<AssessmentResponseDTO>> createAssessment(
+            @Valid @RequestBody AssessmentRequestDTO requestDto,
+            @Parameter(hidden = true) @RequestHeader("X-User-Id") String userIdStr
+    ) {
+        UUID userId = UUID.fromString(userIdStr);
+        AssessmentResponseDTO response = assessmentService.createAssessment(requestDto, userId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "Assessment submitted successfully"));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('DEVELOPER') or hasRole('MANAGER')")
+    public ResponseEntity<ApiResponse<PaginatedResponseDTO<AssessmentResponseDTO>>> getUserAssessments(
+            @RequestHeader("X-User-Id") UUID userId,
+            @ParameterObject Pageable pageable) {
+
+        PaginatedResponseDTO<AssessmentResponseDTO> pagedAssessments = assessmentService.getAssessmentsByUser(userId, pageable);
+        return ResponseEntity.ok(ApiResponse.success(pagedAssessments));
+    }
+
+
+}

--- a/src/main/java/com/talentradar/assessment_service/dto/assessment/request/AssessmentRequestDTO.java
+++ b/src/main/java/com/talentradar/assessment_service/dto/assessment/request/AssessmentRequestDTO.java
@@ -10,15 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class AssessmentRequestDTO {
-    @NotNull
-    private UUID userId;
 
     @NotBlank
     private String reflection;

--- a/src/main/java/com/talentradar/assessment_service/dto/assessment/request/PaginationMetadata.java
+++ b/src/main/java/com/talentradar/assessment_service/dto/assessment/request/PaginationMetadata.java
@@ -1,0 +1,20 @@
+package com.talentradar.assessment_service.dto.assessment.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaginationMetadata {
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+    private boolean hasPrevious;
+}
+

--- a/src/main/java/com/talentradar/assessment_service/dto/assessment/response/PaginatedResponseDTO.java
+++ b/src/main/java/com/talentradar/assessment_service/dto/assessment/response/PaginatedResponseDTO.java
@@ -1,0 +1,21 @@
+package com.talentradar.assessment_service.dto.assessment.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.talentradar.assessment_service.dto.assessment.request.PaginationMetadata;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PaginatedResponseDTO<T> {
+    private List<T> content;
+    private PaginationMetadata pagination;
+}
+

--- a/src/main/java/com/talentradar/assessment_service/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/talentradar/assessment_service/exception/handler/GlobalExceptionHandler.java
@@ -69,6 +69,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ApiResponse<Void>> handleBadRequestException(BadRequestException ex) {
+        log.error("Bad Request Exception: {}", ex.getMessage());
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.error(ex.getMessage(), "Invalid request"));
@@ -76,6 +77,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleNotFoundException(ResourceNotFoundException ex) {
+        log.error("Resource not found: {}", ex.getMessage());
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.error(ex.getMessage(), "Resource not found"));
@@ -83,6 +85,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DuplicateSubmissionException.class)
     public ResponseEntity<ApiResponse<Void>> handleDuplicateSubmission(DuplicateSubmissionException ex) {
+        log.error("Duplicate Submission: {}", ex.getMessage());
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(ApiResponse.error(ex.getMessage(), "Duplicate submission"));

--- a/src/main/java/com/talentradar/assessment_service/filter/UserContextFilter.java
+++ b/src/main/java/com/talentradar/assessment_service/filter/UserContextFilter.java
@@ -1,0 +1,50 @@
+package com.talentradar.assessment_service.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class UserContextFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String userId = request.getHeader("X-User-Id");
+        String userEmail = request.getHeader("X-User-Email");
+        String userRoles = request.getHeader("X-User-Role");
+        String userName = request.getHeader("X-User-UserName");
+        String fullName = request.getHeader("X-User-FullName");
+
+        if (userId != null && userRoles != null) {
+            List<SimpleGrantedAuthority> authorities = Arrays.stream(userRoles.split(","))
+                    .map(String::trim)
+                    .map(SimpleGrantedAuthority::new)
+                    .collect(Collectors.toList());
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+
+

--- a/src/main/java/com/talentradar/assessment_service/mapper/AssessmentMapper.java
+++ b/src/main/java/com/talentradar/assessment_service/mapper/AssessmentMapper.java
@@ -1,6 +1,5 @@
 package com.talentradar.assessment_service.mapper;
 
-import com.talentradar.assessment_service.dto.assessment.request.AssessmentRequestDTO;
 import com.talentradar.assessment_service.dto.assessment.response.AssessmentResponseDTO;
 import com.talentradar.assessment_service.dto.assessment.response.DimensionResponseDTO;
 import com.talentradar.assessment_service.model.Assessment;
@@ -14,15 +13,11 @@ import java.util.List;
 public interface AssessmentMapper {
 
     // Entity to DTO
+    @Mapping(source = "submissionStatus", target = "status")
+    @Mapping(source = "averageScore", target = "average")
     AssessmentResponseDTO toResponseDto(Assessment entity);
 
     DimensionResponseDTO toDimensionDto(AssessmentDimension dimension);
     List<DimensionResponseDTO> toDimensionDtoList(List<AssessmentDimension> dimensions);
 
-
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "createdAt", ignore = true)
-    @Mapping(target = "updatedAt", ignore = true)
-    @Mapping(target = "dimensions", ignore = true)
-    Assessment toEntity(AssessmentRequestDTO dto);
 }

--- a/src/main/java/com/talentradar/assessment_service/model/DimensionDefinition.java
+++ b/src/main/java/com/talentradar/assessment_service/model/DimensionDefinition.java
@@ -42,6 +42,7 @@ public class DimensionDefinition {
     @OneToMany(mappedBy = "dimensionDefinition", cascade = CascadeType.ALL)
     private List<FeedbackDimension> feedbackDimensions;
 
+    @Builder.Default
     @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinTable(
             name = "dimension_grading_criteria",

--- a/src/main/java/com/talentradar/assessment_service/model/GradingCriteria.java
+++ b/src/main/java/com/talentradar/assessment_service/model/GradingCriteria.java
@@ -27,6 +27,7 @@ public class GradingCriteria {
     @Column(name = "criteria_name", nullable = false)
     private String criteriaName;
 
+    @Builder.Default
     @ManyToMany(mappedBy = "gradingCriteriaSet")
     private Set<DimensionDefinition> dimensionDefinitions = new HashSet<>();
 }

--- a/src/main/java/com/talentradar/assessment_service/repository/AssessmentRepository.java
+++ b/src/main/java/com/talentradar/assessment_service/repository/AssessmentRepository.java
@@ -2,11 +2,14 @@ package com.talentradar.assessment_service.repository;
 
 import com.talentradar.assessment_service.model.Assessment;
 import com.talentradar.assessment_service.model.SubmissionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.List;
 
 @Repository
 public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
@@ -16,5 +19,7 @@ public interface AssessmentRepository extends JpaRepository<Assessment, UUID> {
             SubmissionStatus status,
             LocalDateTime after
     ); //Find latest submission (to prevent re-submission within 30 days)
+
+    Page<Assessment> findAllByUserId(UUID userId, Pageable pageable);
 
 }

--- a/src/main/java/com/talentradar/assessment_service/service/AssessmentService.java
+++ b/src/main/java/com/talentradar/assessment_service/service/AssessmentService.java
@@ -1,0 +1,15 @@
+package com.talentradar.assessment_service.service;
+
+import com.talentradar.assessment_service.dto.assessment.request.AssessmentRequestDTO;
+import com.talentradar.assessment_service.dto.assessment.response.AssessmentResponseDTO;
+import com.talentradar.assessment_service.dto.assessment.response.PaginatedResponseDTO;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface AssessmentService {
+    AssessmentResponseDTO createAssessment(AssessmentRequestDTO requestDto, UUID userId);
+    PaginatedResponseDTO<AssessmentResponseDTO> getAssessmentsByUser(UUID userId, Pageable pageable);
+
+
+}

--- a/src/main/java/com/talentradar/assessment_service/service/impl/AssessmentServiceImpl.java
+++ b/src/main/java/com/talentradar/assessment_service/service/impl/AssessmentServiceImpl.java
@@ -1,0 +1,117 @@
+package com.talentradar.assessment_service.service.impl;
+
+import com.talentradar.assessment_service.dto.assessment.request.AssessmentRequestDTO;
+import com.talentradar.assessment_service.dto.assessment.request.DimensionRatingDTO;
+import com.talentradar.assessment_service.dto.assessment.response.AssessmentResponseDTO;
+import com.talentradar.assessment_service.dto.assessment.response.PaginatedResponseDTO;
+import com.talentradar.assessment_service.exception.BadRequestException;
+import com.talentradar.assessment_service.exception.ResourceNotFoundException;
+import com.talentradar.assessment_service.mapper.AssessmentMapper;
+import com.talentradar.assessment_service.model.Assessment;
+import com.talentradar.assessment_service.model.AssessmentDimension;
+import com.talentradar.assessment_service.model.DimensionDefinition;
+import com.talentradar.assessment_service.model.SubmissionStatus;
+import com.talentradar.assessment_service.repository.AssessmentDimensionRepository;
+import com.talentradar.assessment_service.repository.AssessmentRepository;
+import com.talentradar.assessment_service.repository.DimensionDefinitionRepository;
+import com.talentradar.assessment_service.repository.UserSnapshotRepository;
+import com.talentradar.assessment_service.service.AssessmentService;
+import com.talentradar.assessment_service.util.PaginationUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AssessmentServiceImpl implements AssessmentService {
+
+    private final AssessmentRepository assessmentRepository;
+    private final AssessmentDimensionRepository dimensionRepository;
+    private final DimensionDefinitionRepository dimensionDefinitionRepository;
+    private final AssessmentMapper assessmentMapper;
+    private final UserSnapshotRepository userSnapshotRepository;
+
+    @Transactional
+    @Override
+    public AssessmentResponseDTO createAssessment(AssessmentRequestDTO requestDto, UUID userId) {
+
+        userSnapshotRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User with id: " + userId + " not found"));
+
+        validateDimensionDefinitionIds(requestDto.getDimensions());
+
+        reSubmissionValidation(userId);
+
+        Assessment assessment = Assessment.builder()
+                .userId(userId)
+                .reflection(requestDto.getReflection())
+                .submissionStatus(requestDto.getStatus())
+                .build();
+
+        Assessment savedAssessment = assessmentRepository.save(assessment);
+
+        List<AssessmentDimension> dimensions = requestDto.getDimensions().stream()
+                .map(dim -> AssessmentDimension.builder()
+                        .assessment(savedAssessment)
+                        .dimensionDefinition(getDimension(dim.getDimensionDefinitionId()))
+                        .rating(dim.getRating())
+                        .build())
+                .toList();
+
+        dimensionRepository.saveAll(dimensions);
+
+        savedAssessment.setDimensions(dimensions);
+        return assessmentMapper.toResponseDto(savedAssessment);
+    }
+
+    private DimensionDefinition getDimension(UUID id) {
+        return dimensionDefinitionRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("DimensionDefinition with id " + id + " not found"));
+    }
+
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResponseDTO<AssessmentResponseDTO> getAssessmentsByUser(UUID userId, Pageable pageable) {
+        userSnapshotRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with ID: " + userId));
+
+        Page<Assessment> page = assessmentRepository.findAllByUserId(userId, pageable);
+
+        return PaginationUtil.toPaginatedResponse(
+                page.map(assessmentMapper::toResponseDto)
+        );
+    }
+
+    private void validateDimensionDefinitionIds(List<DimensionRatingDTO> ratings) {
+        List<UUID> ids = ratings.stream()
+                .map(DimensionRatingDTO::getDimensionDefinitionId)
+                .toList();
+
+        List<UUID> existingIds = dimensionDefinitionRepository.findExistingIds(ids);
+
+        if (existingIds.size() != ids.size()) {
+            throw new BadRequestException("Some DimensionDefinition IDs are invalid");
+        }
+    }
+
+    private void reSubmissionValidation(UUID userId) {
+        //verify if re-submission is within 30 days
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+
+        boolean recentlySubmitted = assessmentRepository
+                .existsByUserIdAndSubmissionStatusAndCreatedAtAfter(userId, SubmissionStatus.SUBMITTED, thirtyDaysAgo);
+
+        if (recentlySubmitted) {
+            throw new BadRequestException("User has already submitted an assessment within the last 30 days.");
+        }
+    }
+
+}
+

--- a/src/main/java/com/talentradar/assessment_service/util/PaginationUtil.java
+++ b/src/main/java/com/talentradar/assessment_service/util/PaginationUtil.java
@@ -1,0 +1,23 @@
+package com.talentradar.assessment_service.util;
+
+import com.talentradar.assessment_service.dto.assessment.request.PaginationMetadata;
+import com.talentradar.assessment_service.dto.assessment.response.PaginatedResponseDTO;
+import org.springframework.data.domain.Page;
+
+public class PaginationUtil {
+
+    public static <T> PaginatedResponseDTO<T> toPaginatedResponse(Page<T> pageData) {
+        return PaginatedResponseDTO.<T>builder()
+                .content(pageData.getContent())
+                .pagination(PaginationMetadata.builder()
+                        .page(pageData.getNumber())
+                        .size(pageData.getSize())
+                        .totalElements(pageData.getTotalElements())
+                        .totalPages(pageData.getTotalPages())
+                        .hasNext(pageData.hasNext())
+                        .hasPrevious(pageData.hasPrevious())
+                        .build())
+                .build();
+    }
+}
+

--- a/src/test/java/com/talentradar/assessment_service/service/AssessmentServiceImplTest.java
+++ b/src/test/java/com/talentradar/assessment_service/service/AssessmentServiceImplTest.java
@@ -1,0 +1,238 @@
+package com.talentradar.assessment_service.service;
+
+import com.talentradar.assessment_service.dto.assessment.request.AssessmentRequestDTO;
+import com.talentradar.assessment_service.dto.assessment.request.DimensionRatingDTO;
+import com.talentradar.assessment_service.dto.assessment.response.AssessmentResponseDTO;
+import com.talentradar.assessment_service.dto.assessment.response.PaginatedResponseDTO;
+import com.talentradar.assessment_service.exception.BadRequestException;
+import com.talentradar.assessment_service.exception.ResourceNotFoundException;
+import com.talentradar.assessment_service.mapper.AssessmentMapper;
+import com.talentradar.assessment_service.model.Assessment;
+import com.talentradar.assessment_service.model.DimensionDefinition;
+import com.talentradar.assessment_service.model.SubmissionStatus;
+import com.talentradar.assessment_service.model.UserSnapshot;
+import com.talentradar.assessment_service.repository.AssessmentDimensionRepository;
+import com.talentradar.assessment_service.repository.AssessmentRepository;
+import com.talentradar.assessment_service.repository.DimensionDefinitionRepository;
+import com.talentradar.assessment_service.repository.UserSnapshotRepository;
+import com.talentradar.assessment_service.service.impl.AssessmentServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AssessmentServiceImplTest {
+
+    @InjectMocks
+    private AssessmentServiceImpl assessmentService;
+
+    @Mock
+    private AssessmentRepository assessmentRepository;
+
+    @Mock
+    private AssessmentDimensionRepository dimensionRepository;
+
+    @Mock
+    private DimensionDefinitionRepository dimensionDefinitionRepository;
+
+    @Mock
+    private AssessmentMapper assessmentMapper;
+
+    @Mock
+    private UserSnapshotRepository userSnapshotRepository;
+
+    private UUID userId;
+    private UUID dimensionId1;
+    private AssessmentRequestDTO requestDto;
+    private Assessment assessment;
+    private AssessmentResponseDTO responseDto;
+    private DimensionDefinition dimensionDefinition;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        dimensionId1 = UUID.randomUUID();
+
+        requestDto = AssessmentRequestDTO.builder()
+                .reflection("Reflection Text")
+                .status(SubmissionStatus.SUBMITTED)
+                .dimensions(List.of(
+                        DimensionRatingDTO.builder()
+                                .dimensionDefinitionId(dimensionId1)
+                                .rating(4)
+                                .build()))
+                .build();
+
+        assessment = Assessment.builder()
+                .id(UUID.randomUUID())
+                .userId(userId)
+                .reflection("Reflection Text")
+                .submissionStatus(SubmissionStatus.SUBMITTED)
+                .build();
+
+        responseDto = AssessmentResponseDTO.builder()
+                .id(assessment.getId())
+                .userId(userId)
+                .reflection("Reflection Text")
+                .status(SubmissionStatus.SUBMITTED)
+                .build();
+
+        dimensionDefinition = DimensionDefinition.builder()
+                .id(dimensionId1)
+                .dimensionName("Technical Skills")
+                .build();
+    }
+
+    @Test
+    void shouldCreateAssessmentSuccessfully() {
+        when(userSnapshotRepository.findById(userId))
+                .thenReturn(Optional.of(new UserSnapshot()));
+
+        when(assessmentRepository.existsByUserIdAndSubmissionStatusAndCreatedAtAfter(
+                eq(userId),
+                eq(SubmissionStatus.SUBMITTED),
+                any(LocalDateTime.class)))
+                .thenReturn(false);
+
+        when(dimensionDefinitionRepository.findExistingIds(List.of(dimensionId1)))
+                .thenReturn(List.of(dimensionId1));
+
+        when(dimensionDefinitionRepository.findById(dimensionId1))
+                .thenReturn(Optional.of(dimensionDefinition));
+
+        when(assessmentRepository.save(any(Assessment.class)))
+                .thenReturn(assessment);
+
+        when(dimensionRepository.saveAll(anyList()))
+                .thenReturn(Collections.emptyList());
+
+        when(assessmentMapper.toResponseDto(any(Assessment.class)))
+                .thenReturn(responseDto);
+
+        AssessmentResponseDTO result = assessmentService.createAssessment(requestDto, userId);
+
+        assertNotNull(result);
+        assertEquals(userId, result.getUserId());
+        verify(userSnapshotRepository).findById(userId);
+        verify(assessmentRepository).save(any(Assessment.class));
+        verify(dimensionRepository).saveAll(anyList());
+        verify(assessmentMapper).toResponseDto(any(Assessment.class));
+    }
+
+    @Test
+    void shouldThrowBadRequestForInvalidDimensionId() {
+        when(userSnapshotRepository.findById(userId))
+                .thenReturn(Optional.of(new UserSnapshot()));
+
+        when(dimensionDefinitionRepository.findExistingIds(List.of(dimensionId1)))
+                .thenReturn(Collections.emptyList());
+
+        assertThrows(BadRequestException.class, () ->
+                assessmentService.createAssessment(requestDto, userId));
+    }
+
+    @Test
+    void shouldThrowResourceNotFoundIfDimensionMissing() {
+        when(userSnapshotRepository.findById(userId))
+                .thenReturn(Optional.of(new UserSnapshot()));
+
+        when(assessmentRepository.existsByUserIdAndSubmissionStatusAndCreatedAtAfter(
+                eq(userId),
+                eq(SubmissionStatus.SUBMITTED),
+                any(LocalDateTime.class)))
+                .thenReturn(false);
+
+        when(dimensionDefinitionRepository.findExistingIds(List.of(dimensionId1)))
+                .thenReturn(List.of(dimensionId1));
+
+        when(dimensionDefinitionRepository.findById(dimensionId1))
+                .thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () ->
+                assessmentService.createAssessment(requestDto, userId));
+    }
+
+    @Test
+    void shouldThrowBadRequestIfUserSubmittedWithin30Days() {
+        when(userSnapshotRepository.findById(userId))
+                .thenReturn(Optional.of(new UserSnapshot()));
+
+        when(dimensionDefinitionRepository.findExistingIds(List.of(dimensionId1)))
+                .thenReturn(List.of(dimensionId1));
+
+        when(assessmentRepository.existsByUserIdAndSubmissionStatusAndCreatedAtAfter(
+                eq(userId),
+                eq(SubmissionStatus.SUBMITTED),
+                any(LocalDateTime.class)))
+                .thenReturn(true); // simulate 30-day restriction
+
+        BadRequestException exception = assertThrows(BadRequestException.class,
+                () -> assessmentService.createAssessment(requestDto, userId));
+
+        assertEquals("User has already submitted an assessment within the last 30 days.", exception.getMessage());
+    }
+
+    @Test
+    void shouldReturnPaginatedAssessmentsByUser() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Assessment> assessments = List.of(assessment);
+
+        when(userSnapshotRepository.findById(userId))
+                .thenReturn(Optional.of(new UserSnapshot()));
+
+        when(assessmentRepository.findAllByUserId(userId, pageable))
+                .thenReturn(new PageImpl<>(assessments));
+
+        when(assessmentMapper.toResponseDto(any(Assessment.class)))
+                .thenReturn(responseDto);
+
+        // Act
+        PaginatedResponseDTO<AssessmentResponseDTO> result = assessmentService.getAssessmentsByUser(userId, pageable);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getContent().size());
+        assertEquals(userId, result.getContent().get(0).getUserId());
+        verify(assessmentRepository).findAllByUserId(userId, pageable);
+        verify(assessmentMapper).toResponseDto(any(Assessment.class));
+    }
+
+    @Test
+    void shouldThrowResourceNotFoundIfUserDoesNotExistForPagination() {
+        // Arrange
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(userSnapshotRepository.findById(userId))
+                .thenReturn(Optional.empty());
+
+        // Act & Assert
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
+                () -> assessmentService.getAssessmentsByUser(userId, pageable));
+
+        assertEquals("User not found with ID: " + userId, exception.getMessage());
+        verify(userSnapshotRepository).findById(userId);
+        verifyNoInteractions(assessmentRepository, assessmentMapper);
+    }
+
+}
+
+
+
+


### PR DESCRIPTION
## 🔗 Jira Issue  
Closes [TRA-31](https://amali-tech.atlassian.net/jira/software/projects/TRA/boards/1721?selectedIssue=TRA-31) ,[TRA-29](https://amali-tech.atlassian.net/jira/software/projects/TRA/boards/1721?selectedIssue=TRA-29)

---

## 📄 Description  

This PR introduces the **Assessment Creation** and **Paginated Retrieval** features for the `assessment-service` and the `AssessmentController`. It includes business logic to validate user existence, prevent re-submission within 30 days, and ensures all submitted dimensions are valid.

**Modules Affected**:  
- `AssessmentController`
- `AssessmentServiceImpl`  
- `AssessmentRepository`, `DimensionDefinitionRepository`  
- DTOs, pagination utilities, and unit tests  

---

## ✅ Implemented Features

### 🔹 Assessment Creation (`POST /api/assessments`)
- Extracts userId from `X-User-Id` header
- Validates user existence in `user_snapshot` table
- Rejects duplicate submissions within 30 days (if status = SUBMITTED)
- Validates dimensionDefinition IDs exist in DB
- Persists Assessment + its Dimensions
- Returns `AssessmentResponseDTO`

### 🔹 Paginated Retrieval (`GET /api/assessments`)
- Accepts `Pageable` params to return paginated data
- Fetches assessments for current user
- Validates user exists
- Returns wrapped `PaginatedResponseDTO<AssessmentResponseDTO>` using `ApiResponse<T>`

---

## 🧪 How to Test

1. Run the service and hit `POST /api/assessments` with a valid payload and `X-User-Id` header
2. Submit again within 30 days → Should throw `BadRequestException`
3. Hit `GET /api/assessments?page=0&size=5` → Should return paginated assessments
4. Try with a non-existing user ID → Should return `ResourceNotFoundException`

---

## ✅ Checklist

- [x] Jira ticket linked in description
- [x] Follows branch naming convention: `feature/create-assessment-service-TRA-31`
- [x] Follows commit naming convention: `feat: Add assessment creation and retrieval`
- [x] Code tested locally
- [x] Unit tests added
- [x] No sensitive data committed

---

## 🧪 Unit Tests Added

- ✔️ `createAssessment` 
- ✔️ `BadRequestException` on invalid dimension
- ✔️ `ResourceNotFoundException` on missing dimension
- ✔️ `BadRequestException` if assessment re-submitted within 30 days
- ✔️ `getAssessmentsByUser` with valid user and pageable
- ✔️ `getAssessmentsByUser` throws `ResourceNotFoundException` if user not found

---

## 🔧 DTOs & Utils

- ✅ `PaginatedResponseDTO<T>` & `PaginationUtil`
- ✅ Unified response using `ApiResponse<T>`

---

## 📝 Additional Notes

- 🔐 Authentication/authorization context is extracted from headers (`X-User-Id`)
- ♻️ Structure is designed to support future caching and performance tuning
- 🧼 Verified all Mockito stubbings are necessary (no warnings)
- 🧪 All tests pass successfully
